### PR TITLE
公開鍵と秘密鍵出力先をドメイン毎に出力するように修正

### DIFF
--- a/certs/Dockerfile
+++ b/certs/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:latest
 
-WORKDIR /app
+ARG DOMAIN
+WORKDIR /app/${DOMAIN}
 
 RUN apk update && \
   apk add openssl
 
-CMD openssl req -x509 -nodes -newkey rsa:4096 -sha256 -days 365 \
-  -keyout '${DOMAIN}/privkey.pem' \
-  -out '${DOMAIN}/fullchain.pem' \
-  -subj "/CN=localhost"
+ENV PRIKEY=/app/${DOMAIN}/privkey.pem
+ENV PUBKEY=/app/${DOMAIN}/fullchain.pem
+CMD openssl req -x509 -nodes -newkey rsa:4096 -sha256 -days 365 -keyout ${PRIKEY} -out ${PUBKEY} -subj "/CN=localhost"

--- a/certs/Dockerfile
+++ b/certs/Dockerfile
@@ -5,9 +5,7 @@ WORKDIR /app
 RUN apk update && \
   apk add openssl
 
-CMD openssl req -x509 -newkey rsa:4096 -sha256 -days 365 -nodes \
-  -keyout domain.key \
-  -out signed.crt \
-  -subj "/CN=${DOMAIN}" \
-  -addext "subjectAltName=DNS:${DOMAIN}" \
-  -addext "extendedKeyUsage=serverAuth"
+CMD openssl req -x509 -nodes -newkey rsa:4096 -sha256 -days 365 \
+  -keyout '${DOMAIN}/privkey.pem' \
+  -out '${DOMAIN}/fullchain.pem' \
+  -subj "/CN=localhost"

--- a/deploy/init-letsencrypt.sh
+++ b/deploy/init-letsencrypt.sh
@@ -18,6 +18,7 @@ if [ -d "$data_path" ]; then
   fi
 fi
 
+
 if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
   echo "### Downloading recommended TLS parameters ..."
   mkdir -p "$data_path/conf"
@@ -27,12 +28,12 @@ if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/
 fi
 
 echo "### Creating dummy certificate for $domains ..."
-path="/etc/letsencrypt/live"
-mkdir -p "$data_path/conf/live"
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
 docker-compose run --rm --entrypoint "\
   openssl req -x509 -nodes -newkey rsa:$rsa_key_size -days 1\
-    -keyout '$path/domain.key' \
-    -out '$path/signed.crt' \
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
     -subj '/CN=localhost'" certbot
 echo
 
@@ -43,8 +44,8 @@ echo
 
 echo "### Deleting dummy certificate for $domains ..."
 docker-compose run --rm --entrypoint "\
-  rm -Rf /etc/letsencrypt/live && \
-  rm -Rf /etc/letsencrypt/archive && \
+  rm -Rf /etc/letsencrypt/live/$domains && \
+  rm -Rf /etc/letsencrypt/archive/$domains && \
   rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
 echo
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - gunicorn:/var/run/gunicorn
       - static:/var/www/static
       - media:/var/www/media
-      - certs:/etc/letsencrypt/live:ro,cached
+      - certs:/etc/letsencrypt/live
     environment:
       SERVER_NAME: ${SERVER_NAME}
     ports:
@@ -23,8 +23,8 @@ services:
     build:
       context: .
       dockerfile: certs/Dockerfile
-    environment:
-      DOMAIN: ${SERVER_NAME}
+      args:
+        - DOMAIN=${SERVER_NAME}
     volumes:
       - certs:/app:delegated
 

--- a/web/gunicorn.conf
+++ b/web/gunicorn.conf
@@ -16,12 +16,10 @@ server {
 
 server {
     listen 443 ssl;
-    server_name ${SERVER_NAME};
+    server_name ${SERVER_NAME} www.${SERVER_NAME};
 
-    set $ssl_crt /etc/letsencrypt/live/${SERVER_NAME}/fullchain.pem;
-    set $ssl_key /etc/letsencrypt/live/${SERVER_NAME}/privkey.pem;
-    ssl_certificate $ssl_crt;
-    ssl_certificate_key $ssl_key;
+    ssl_certificate /etc/letsencrypt/live/kchihogi.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/kchihogi.com/privkey.pem;
 
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;

--- a/web/gunicorn.conf
+++ b/web/gunicorn.conf
@@ -18,8 +18,10 @@ server {
     listen 443 ssl;
     server_name ${SERVER_NAME};
 
-    ssl_certificate /etc/letsencrypt/live/signed.crt;
-    ssl_certificate_key /etc/letsencrypt/live/domain.key;
+    set $ssl_crt /etc/letsencrypt/live/${SERVER_NAME}/fullchain.pem;
+    set $ssl_key /etc/letsencrypt/live/${SERVER_NAME}/privkey.pem;
+    ssl_certificate $ssl_crt;
+    ssl_certificate_key $ssl_key;
 
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;


### PR DESCRIPTION
certコンテナ内でドメイン配下に公開鍵と秘密鍵を生成するように修正
ssl_certificate/ssl_certificate_keyに変数を指定することが出来ない